### PR TITLE
Optional error color and optional okText color.

### DIFF
--- a/RevoValidation/src/Validation.swift
+++ b/RevoValidation/src/Validation.swift
@@ -15,6 +15,9 @@ public class Validation {
     var okText = ""
     var delegate:ValidationDelegate?
     
+    var errorLabelColor:UIColor?
+    var okTextColor:UIColor?
+    
     public init(field:UITextField, rules:Rules){
         self.field = field
         self.rules = rules
@@ -37,9 +40,14 @@ public class Validation {
         return self
     }
     
-    public func withOkText(_ text:String) -> Validation{
+    public func withOkText(_ text:String, _ color:UIColor? = nil) -> Validation{
         okText = text
+        (color != nil) ? okTextColor = color : nil
         return self
+    }
+    
+    public func addErrorColor(_ color:UIColor) {
+        errorLabelColor = color
     }
     
     @objc func inputChanged(){
@@ -53,7 +61,11 @@ public class Validation {
         if showErrors {
             field.rightViewMode = failed.count == 0 ? .never : .always
             errorsLabel?.text = failed.errorMessage
-            if failed.count == 0 { errorsLabel?.text = okText }
+            (errorLabelColor != nil) ? errorsLabel?.textColor = errorLabelColor : nil
+            if failed.count == 0 {
+                errorsLabel?.text = okText
+                (okTextColor != nil) ? errorsLabel?.textColor = okTextColor : nil
+            }
         }
         return failed.count == 0
     }


### PR DESCRIPTION
No he sapigut posar el color opcional del "Perfect" només i que quan no sigui "Perfect", i hi hagi un altre error, torni al color per defecte del storyboard. Així que he optat per poder afegir el color del error opcionalment també a través de la llibreria.

Això si, si afegeixes o el color del error o el color del Perfect, has d'afegir l'altre, perqué si només afegeixes 1, quan es compleix la condició del color en aquell camp (ex. només el Perfect en verd) després els errors estan en verd, a no ser que possis color als errors. Això és així pel que t'he comentat, que no sé com agafar o guardar permanentment el color del storyboard...

Si no et mola aquesta opció, diguem com ho hauria de encaminar exactament!