### PR TITLE
New rule: Combined rule, ShouldShowFirstOne optional option Validation & default color correction.

### DIFF
--- a/RevoValidation/src/Rules.swift
+++ b/RevoValidation/src/Rules.swift
@@ -6,17 +6,32 @@ public struct Rules : ExpressibleByStringLiteral {
     
     public init(stringLiteral value: String) {
         self.rules = value.explode("|").compactMap {
-            let params = $0.explode(":")
-            switch params.first! {
-            case "required"             : return RuleRequired()
-            case "email"                : return RuleEmail()
-            case "containsSpecialChars" : return RuleContainSpecialChars()
-            case "containsNumber"       : return RuleContainsNumber()
-            case "numeric"              : return RuleNumeric()
-            case "length"               : return RuleLenght(Int(params.last ?? "3") ?? 3)
-            case "age"                  : return RuleAge(Int(params.last ?? "18") ?? 18)
-            default                     : return nil
+            if !$0.contains("+") {
+                let params = $0.explode(":")
+                switch params.first! {
+                case "required"             : return RuleRequired()
+                case "email"                : return RuleEmail()
+                case "containsSpecialChars" : return RuleContainSpecialChars()
+                case "containsNumber"       : return RuleContainsNumber()
+                case "numeric"              : return RuleNumeric()
+                case "length"               : return RuleLenght(Int(params.last ?? "3") ?? 3)
+                case "age"                  : return RuleAge(Int(params.last ?? "18") ?? 18)
+                default                     : return nil
+                }
             }
+            return RuleCombined($0.explode("+").compactMap {
+                let params = $0.explode(":")
+                switch params.first! {
+                case "required"             : return RuleRequired()
+                case "email"                : return RuleEmail()
+                case "containsSpecialChars" : return RuleContainSpecialChars()
+                case "containsNumber"       : return RuleContainsNumber()
+                case "numeric"              : return RuleNumeric()
+                case "length"               : return RuleLenght(Int(params.last ?? "3") ?? 3)
+                case "age"                  : return RuleAge(Int(params.last ?? "18") ?? 18)
+                default                     : return nil
+                }
+            }, $0)
         }
     }
     

--- a/RevoValidation/src/Rules.swift
+++ b/RevoValidation/src/Rules.swift
@@ -52,7 +52,7 @@ public struct Rules : ExpressibleByStringLiteral {
         rules.map { $0.errorMessage }.map { NSLocalizedString($0, comment: $0) } .implode(" | ")
     }
     
-    public var showFirstErrorMessage:String {
+    public var shouldShowFirstErrorMessage:String {
         guard rules.isEmpty == false else { return "" }
         return NSLocalizedString(rules[0].errorMessage, comment: rules[0].errorMessage)
     }

--- a/RevoValidation/src/Rules.swift
+++ b/RevoValidation/src/Rules.swift
@@ -6,12 +6,12 @@ public struct Rules : ExpressibleByStringLiteral {
     
     public init(stringLiteral value: String) {
         self.rules = value.explode("|").compactMap {
-            if !$0.contains("+") { return Rules.getRule($0) }
-            return RuleCombined($0.explode("+").compactMap { return Rules.getRule($0) }, $0)
+            if !$0.contains("+") { return Rules.makeRule($0) }
+            return RuleCombined($0.explode("+").compactMap { return Rules.makeRule($0) }, $0)
         }
     }
     
-    static func getRule(_ rule:String) -> Rule? {
+    static func makeRule(_ rule:String) -> Rule? {
         let params = rule.explode(":")
         switch params.first! {
         case "required"             : return RuleRequired()

--- a/RevoValidation/src/Rules.swift
+++ b/RevoValidation/src/Rules.swift
@@ -52,5 +52,11 @@ public struct Rules : ExpressibleByStringLiteral {
         rules.map { $0.errorMessage }.map { NSLocalizedString($0, comment: $0) } .implode(" | ")
     }
     
+    public var showFirstErrorMessage:String {
+        print(rules)
+        guard rules.isEmpty == false else { return "" }
+        return NSLocalizedString(rules[0].errorMessage, comment: rules[0].errorMessage)
+    }
+    
     public var count:Int { rules.count }
 }

--- a/RevoValidation/src/Rules.swift
+++ b/RevoValidation/src/Rules.swift
@@ -52,5 +52,10 @@ public struct Rules : ExpressibleByStringLiteral {
         rules.map { $0.errorMessage }.map { NSLocalizedString($0, comment: $0) } .implode(" | ")
     }
     
+    public var showFirstErrorMessage:String {
+        guard rules.isEmpty == false else { return "" }
+        return NSLocalizedString(rules[0].errorMessage, comment: rules[0].errorMessage)
+    }
+    
     public var count:Int { rules.count }
 }

--- a/RevoValidation/src/Rules.swift
+++ b/RevoValidation/src/Rules.swift
@@ -6,32 +6,22 @@ public struct Rules : ExpressibleByStringLiteral {
     
     public init(stringLiteral value: String) {
         self.rules = value.explode("|").compactMap {
-            if !$0.contains("+") {
-                let params = $0.explode(":")
-                switch params.first! {
-                case "required"             : return RuleRequired()
-                case "email"                : return RuleEmail()
-                case "containsSpecialChars" : return RuleContainSpecialChars()
-                case "containsNumber"       : return RuleContainsNumber()
-                case "numeric"              : return RuleNumeric()
-                case "length"               : return RuleLenght(Int(params.last ?? "3") ?? 3)
-                case "age"                  : return RuleAge(Int(params.last ?? "18") ?? 18)
-                default                     : return nil
-                }
-            }
-            return RuleCombined($0.explode("+").compactMap {
-                let params = $0.explode(":")
-                switch params.first! {
-                case "required"             : return RuleRequired()
-                case "email"                : return RuleEmail()
-                case "containsSpecialChars" : return RuleContainSpecialChars()
-                case "containsNumber"       : return RuleContainsNumber()
-                case "numeric"              : return RuleNumeric()
-                case "length"               : return RuleLenght(Int(params.last ?? "3") ?? 3)
-                case "age"                  : return RuleAge(Int(params.last ?? "18") ?? 18)
-                default                     : return nil
-                }
-            }, $0)
+            if !$0.contains("+") { return Rules.getRule($0) }
+            return RuleCombined($0.explode("+").compactMap { return Rules.getRule($0) }, $0)
+        }
+    }
+    
+    static func getRule(_ rule:String) -> Rule? {
+        let params = rule.explode(":")
+        switch params.first! {
+        case "required"             : return RuleRequired()
+        case "email"                : return RuleEmail()
+        case "containsSpecialChars" : return RuleContainSpecialChars()
+        case "containsNumber"       : return RuleContainsNumber()
+        case "numeric"              : return RuleNumeric()
+        case "length"               : return RuleLenght(Int(params.last ?? "3") ?? 3)
+        case "age"                  : return RuleAge(Int(params.last ?? "18") ?? 18)
+        default                     : return nil
         }
     }
     
@@ -52,7 +42,7 @@ public struct Rules : ExpressibleByStringLiteral {
         rules.map { $0.errorMessage }.map { NSLocalizedString($0, comment: $0) } .implode(" | ")
     }
     
-    public var shouldShowFirstErrorMessage:String {
+    public var firstErrorMessage:String {
         guard rules.isEmpty == false else { return "" }
         return NSLocalizedString(rules[0].errorMessage, comment: rules[0].errorMessage)
     }

--- a/RevoValidation/src/Rules/RuleCombined.swift
+++ b/RevoValidation/src/Rules/RuleCombined.swift
@@ -3,17 +3,17 @@ import RevoFoundation
 
 public class RuleCombined : Rule {
  
-    var titleTraduction:String
-    var combinedRules:[Rule]
+    var title:String
+    var rules:[Rule]
     
-    override var errorMessage: String{ titleTraduction }
+    override var errorMessage: String{ title }
     
     public init(_ rules:[Rule], _ title:String){
-        self.combinedRules = rules
-        self.titleTraduction = title
+        self.rules = rules
+        self.title = title
     }
     
     override public func isValid(_ text:String) -> Bool {
-        combinedRules.contains{ $0.isValid(text) }
+        rules.contains{ $0.isValid(text) }
     }
 }

--- a/RevoValidation/src/Rules/RuleCombined.swift
+++ b/RevoValidation/src/Rules/RuleCombined.swift
@@ -1,0 +1,19 @@
+import Foundation
+import RevoFoundation
+
+public class RuleCombined : Rule {
+ 
+    var titleTraduction:String
+    var combinedRules:[Rule]
+    
+    override var errorMessage: String{ titleTraduction }
+    
+    public init(_ rules:[Rule], _ title:String){
+        self.combinedRules = rules
+        self.titleTraduction = title
+    }
+    
+    override public func isValid(_ text:String) -> Bool {
+        combinedRules.contains{ $0.isValid(text) }
+    }
+}

--- a/RevoValidation/src/Validation.swift
+++ b/RevoValidation/src/Validation.swift
@@ -70,7 +70,7 @@ public class Validation {
     func showErrorslabel(){
         field.rightViewMode = failed.count == 0 ? .never : .always
         errorsLabel?.text = (showFirstOneFlag ? failed.showFirstErrorMessage : failed.errorMessage)
-        showDefaultColor()
+        if okTextColor != nil { showDefaultColor() }
         if failed.count == 0 {
             errorsLabel?.text = okText
             if okTextColor != nil { errorsLabel?.textColor = okTextColor }

--- a/RevoValidation/src/Validation.swift
+++ b/RevoValidation/src/Validation.swift
@@ -15,7 +15,7 @@ public class Validation {
     var okText = ""
     var delegate:ValidationDelegate?
     
-    var showFirstOneFlag:Bool = false
+    var shouldShowFirstOneFlag:Bool = false
     
     var defaultColor:UIColor?
     var okTextColor:UIColor?
@@ -48,8 +48,8 @@ public class Validation {
         return self
     }
     
-    public func showFirstOne() -> Validation {
-        showFirstOneFlag = true
+    public func shouldShowFirstOne() -> Validation {
+        shouldShowFirstOneFlag = true
         return self
     }
     
@@ -69,8 +69,9 @@ public class Validation {
     
     func showErrorslabel(){
         field.rightViewMode = failed.count == 0 ? .never : .always
-        errorsLabel?.text = (showFirstOneFlag ? failed.showFirstErrorMessage : failed.errorMessage)
+        errorsLabel?.text = (shouldShowFirstOneFlag ? failed.shouldShowFirstErrorMessage : failed.errorMessage)
         if okTextColor != nil { showDefaultColor() }
+//        showDefaultColor()
         if failed.count == 0 {
             errorsLabel?.text = okText
             if okTextColor != nil { errorsLabel?.textColor = okTextColor }
@@ -79,6 +80,7 @@ public class Validation {
     
     func showDefaultColor() {
         if defaultColor == nil { defaultColor = errorsLabel?.textColor }
+//        print("enter showdefaultcolor")
         errorsLabel?.textColor = defaultColor
     }
     

--- a/RevoValidation/src/Validation.swift
+++ b/RevoValidation/src/Validation.swift
@@ -15,6 +15,8 @@ public class Validation {
     var okText = ""
     var delegate:ValidationDelegate?
     
+    var showFirstOneFlag:Bool = false
+    
     var defaultColor:UIColor?
     var okTextColor:UIColor?
     
@@ -40,9 +42,14 @@ public class Validation {
         return self
     }
     
-    public func withOkText(_ text:String, _ color:UIColor? = nil) -> Validation{
+    public func withOkText(_ text:String, _ color:UIColor? = nil) -> Validation {
         okText = text
         okTextColor = color
+        return self
+    }
+    
+    public func showFirstOne() -> Validation {
+        showFirstOneFlag = true
         return self
     }
     
@@ -62,7 +69,7 @@ public class Validation {
     
     func showErrorslabel(){
         field.rightViewMode = failed.count == 0 ? .never : .always
-        errorsLabel?.text = failed.errorMessage
+        errorsLabel?.text = (showFirstOneFlag ? failed.showFirstErrorMessage : failed.errorMessage)
         showDefaultColor()
         if failed.count == 0 {
             errorsLabel?.text = okText

--- a/RevoValidation/src/Validation.swift
+++ b/RevoValidation/src/Validation.swift
@@ -15,7 +15,7 @@ public class Validation {
     var okText = ""
     var delegate:ValidationDelegate?
     
-    var shouldShowFirstOneFlag:Bool = false
+    var shouldShowFirstOne:Bool = false
     
     var defaultColor:UIColor?
     var okTextColor:UIColor?
@@ -48,8 +48,8 @@ public class Validation {
         return self
     }
     
-    public func shouldShowFirstOne() -> Validation {
-        shouldShowFirstOneFlag = true
+    public func shouldShowFirstOne(_ shouldShowFirstOne:Bool = true) -> Validation {
+        self.shouldShowFirstOne = shouldShowFirstOne
         return self
     }
     
@@ -69,7 +69,7 @@ public class Validation {
     
     func showErrorslabel(){
         field.rightViewMode = failed.count == 0 ? .never : .always
-        errorsLabel?.text = (shouldShowFirstOneFlag ? failed.shouldShowFirstErrorMessage : failed.errorMessage)
+        errorsLabel?.text = (shouldShowFirstOne ? failed.firstErrorMessage : failed.errorMessage)
         if okTextColor != nil { showDefaultColor() }
 //        showDefaultColor()
         if failed.count == 0 {


### PR DESCRIPTION
**New rule: Combined rule.**
Condition: Some rules, when one of them is passed, the combined rules are passed.
Example of use: Validation(TextField,   "containsSpecialChars+containsNumber", errorLabel)
Key identifier: "+"

**ShouldShowFirstOne optional option Validation.**
Added shouldShowFirstOne() (optional) option in validation, to show only the first message error in the rules:
Validation(TextField,   "required|containsSpecialChars+containsNumber", errorLabel).shouldShowFirstOne()
-> this will show only "required" message first, when this passed, it will show only "containsSpecialChars+containsNumber" message, unless is also passed.

**Default color correction.**
Now, the default color only is defined and used if okText color is used.